### PR TITLE
Remove unnecessary proxying function

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,6 @@ const fromIter = require("callbag-from-iter");
 const flatten = require("callbag-flatten");
 const map = require("callbag-map");
 
-const flattenIter = source => flatten(map(i => fromIter(i))(source));
+const flattenIter = source => flatten(map(fromIter)(source));
 
 module.exports = flattenIter;


### PR DESCRIPTION
Both are equivalent, but the proposed change is shorted and doesnt produce extra function (so slightly better memory-wise)